### PR TITLE
SSEOxyGent payload exclude callee/callee_category

### DIFF
--- a/oxygent/oxy/agents/sse_oxy_agent.py
+++ b/oxygent/oxy/agents/sse_oxy_agent.py
@@ -44,7 +44,7 @@ class SSEOxyGent(RemoteAgent):
             },
         )
         payload = oxy_request.model_dump(
-            exclude={"mas", "parallel_id", "latest_node_ids"}
+            exclude={"mas", "parallel_id", "latest_node_ids", "callee", "callee_category"}
         )
         payload.update(payload["arguments"])
         payload["caller_category"] = "user"


### PR DESCRIPTION
### Summary
修改 `SSEOxyGent` 请求外部MAS应用的 `payload` ，剔除参数 `callee` 和 `callee_category`。

### Why
&emsp;&emsp;`SSEOxyGent` 能够做MAS应用之间的集成，在 `MAS.chat_with_agent` 方法的实现中（如下），会优先从http请求的 `payload` 中获取 `callee`。这也就意味着：如果SSEOxyGent实例在调用外部MAS系统 `/sse/chat` 接口时把自身的 `callee` 和 `callee_category` 传输过去了，将会发生以下情况：
* 外部MAS系统没有同名的节点，调用异常（具体取决于外部MAS系统的实现）
* 外部MAS系统有同名节点，但并不是期望的功能，返回错误的结果
* 外部MAS系统有同名节点，且是预期功能，能够得到期望的结果
```python
            oxy_request_fields = oxy_request.model_fields
            for k, v in payload.items():
                if k in oxy_request_fields:
                    setattr(oxy_request, k, v)
                else:
                    oxy_request.arguments[k] = v

            if not oxy_request.callee:
                oxy_request.callee = self.master_agent_name
```
&emsp;&emsp;这也就意味着，必须要知道外部MAS系统的节点名称，并且保证自己的SSEOxyGent节点名称与之想通，才能够得到正确的结果，这会导致系统之间的耦合！如果默认把 `callee` 和 `callee_category` 从 `payload` 中排除，在调用外部MAS系统的 `/sse/chat` 接口时，会默认从它的master节点开始执行，这应该是一个惯性思维下想要的结果。另外，在调用SSEOxyGent实例之前，在 `oxy_request.arguments` 中传输 `callee` 参数，依旧能够达到指定调用外部MAS系统某一个节点能力的效果（但个人感觉这不是一个好的用法，外部MAS系统的改造随时会带来可用性上的风险），因为在 SSEOxyGent 中处理`payload` 时优先采用了 `oxy_request.arguments` 中的参数（如下）：
```python
       payload = oxy_request.model_dump(
            exclude={"mas", "parallel_id", "latest_node_ids", "callee", "callee_category"}   # 这里本次做了修改
        )
        payload.update(payload["arguments"])
```
&emsp;&emsp;基于以上，提出这个细微的调整

### Checklist

- [ ] been self-reviewed.
    - [ ] Code is formatted
    - [ ] Tests added/updated
    - [ ] All CI checks passed
    - [ ] Documentation updated
- [ ] added documentation for new or modified features or behaviors.
- [ ] added new features, such as new agents, new flows, etc. 
- [ ] added or updated version, __license__, or notice information.
- [ ] added or updated demo, integration tests, unit tests, or others.
- [ ] added or updated ui, or had changes in frontend.

