### PR TITLE
feat(rag): add context overflow protection with TRUNCATE/RAISE/MAP_REDUCE strategies

### DIFF
--- a/oxygent/oxy/agents/local_agent.py
+++ b/oxygent/oxy/agents/local_agent.py
@@ -180,16 +180,25 @@ class LocalAgent(BaseAgent):
                 logger.warning(f"Unknown bank type: {type(oxy)}")
 
     def __deepcopy__(self, memo: dict[int, Any]) -> "LocalAgent":
-        """Deep copy this agent, preserving non-copyable async primitives."""
-        # Extract all fields from the current instance
-        fields = self.model_dump()
+        """Deep copy this agent, preserving non-copyable async primitives.
 
+        Re-injects any field declared with ``exclude=True`` (e.g. callables) that
+        ``model_dump()`` omits, so subclasses with excluded required fields copy
+        correctly without overriding this method.
+        """
+        fields = self.model_dump()
+        # Re-inject exclude=True fields that model_dump() drops
+        for name, info in type(self).model_fields.items():
+            if info.exclude:
+                fields[name] = getattr(self, name)
         # Keep MAS reference shared (not deep copied) to maintain system connectivity
         fields["mas"] = self.mas
 
         # Deep copy all other fields to ensure complete isolation
         for k in fields:
-            if k not in ["mas"]:
+            if k not in ("mas",) and not (
+                k in type(self).model_fields and type(self).model_fields[k].exclude
+            ):
                 fields[k] = copy.deepcopy(fields[k], memo)
         return self.__class__(**fields)
 

--- a/oxygent/oxy/agents/rag_agent.py
+++ b/oxygent/oxy/agents/rag_agent.py
@@ -2,37 +2,292 @@
 
 Provides the RAGAgent class which augments LLM responses with retrieved context."""
 
-from typing import Callable
+import asyncio
+import logging
+from enum import Enum
+from pydantic import Field, field_validator, model_validator
+from typing import Callable, Optional
 
-from pydantic import Field, model_validator
-
-from ...schemas.oxy import OxyRequest
 from .chat_agent import ChatAgent
+from ...schemas import Memory, Message
+from ...schemas.oxy import OxyRequest, OxyState
+from ...utils.token_utils import KnowledgeTruncator, TokenEstimator
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_COLLAPSE_PROMPT = (
+    "Please summarise the following text concisely, preserving the key facts:\n\n{text}"
+)
+
+
+class OverflowStrategy(str, Enum):
+    """Strategy to apply when retrieved knowledge exceeds the token budget.
+
+    - IGNORE:         pass the full text unchanged (original behaviour, default).
+    - TRUNCATE:       keep the largest fitting prefix, log a warning, continue.
+    - RAISE:          raise ValueError immediately so the caller can decide.
+    - MAP_REDUCE:     split into chunks, summarise each with the LLM, then
+                      recursively collapse until the result fits the budget.
+    """
+
+    TRUNCATE = "truncate"
+    RAISE = "raise"
+    IGNORE = "ignore"
+    MAP_REDUCE = "map_reduce"
 
 
 class RAGAgent(ChatAgent):
-    """A retrieval-augmented agent that fetches relevant context before LLM generation."""
+    """A retrieval-augmented agent that fetches relevant context before LLM generation.
 
-    knowledge_placeholder: str = Field("knowledge")
+    Context-window protection
+    -------------------------
+    Set ``max_knowledge_tokens`` to a positive integer to enable overflow
+    detection.  When the retrieved knowledge exceeds that budget:
+
+    * ``overflow_strategy=IGNORE`` (default) — passes the full text unchanged (original behaviour).
+    * ``overflow_strategy=TRUNCATE`` — silently truncates and logs a warning.
+    * ``overflow_strategy=RAISE``    — raises ``ValueError``.
+    * ``overflow_strategy=MAP_REDUCE`` — splits into chunks, summarises each with the LLM,
+      then recursively collapses until the combined summary fits the budget.
+      Requires ``max_knowledge_tokens`` to be set.
+    """
+
+    knowledge_placeholder: str = Field("knowledge", min_length=1)
 
     func_retrieve_knowledge: Callable = Field(
         exclude=True, description="Retrieve knowledge function"
     )
+
+    # ---- context-window protection fields -----------------------------------
+    max_knowledge_tokens: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Maximum tokens allowed for retrieved knowledge. "
+            "None disables overflow checking (legacy behaviour)."
+        ),
+    )
+    overflow_strategy: OverflowStrategy = Field(
+        default=OverflowStrategy.IGNORE,
+        description="Action to take when retrieved knowledge exceeds max_knowledge_tokens.",
+    )
+    collapse_prompt: str = Field(
+        default=_DEFAULT_COLLAPSE_PROMPT,
+        description=(
+            "Prompt template used when overflow_strategy=MAP_REDUCE to summarise each chunk. "
+            "Must contain the placeholder '{text}'."
+        ),
+    )
+    collapse_max_retries: int = Field(
+        default=3,
+        ge=1,
+        description=(
+            "Maximum number of recursive collapse rounds for MAP_REDUCE strategy "
+            "before raising ValueError."
+        ),
+    )
+
+    @field_validator("collapse_prompt")
+    @classmethod
+    def _validate_collapse_prompt(cls, v: str) -> str:
+        if "{text}" not in v:
+            raise ValueError(
+                "collapse_prompt must contain the '{text}' placeholder; "
+                f"got: {v!r}"
+            )
+        try:
+            v.format(text="")
+        except (KeyError, IndexError, ValueError) as exc:
+            raise ValueError(
+                f"collapse_prompt contains an unresolvable placeholder: {exc}. "
+                "Only '{text}' is supported."
+            ) from exc
+        return v
 
     @model_validator(mode="after")
     def set_default_prompt(self) -> "RAGAgent":
         """Pydantic model validator that injects the default RAG prompt if none provided."""
         if not self.prompt:
             self.prompt = (
-                "You are a helpful assistant. You can refer to the following information to answer the questions.\n${"
-                + self.knowledge_placeholder
-                + "}"
+                    "You are a helpful assistant. You can refer to the following information to answer the questions.\n${"
+                    + self.knowledge_placeholder
+                    + "}"
+            )
+        if self.overflow_strategy == OverflowStrategy.MAP_REDUCE and self.max_knowledge_tokens is None:
+            logger.warning(
+                "RAGAgent '%s': overflow_strategy=MAP_REDUCE requires max_knowledge_tokens to be set; "
+                "knowledge will be passed through unchanged until max_knowledge_tokens is configured.",
+                self.name,
             )
         return self
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    def knowledge_fits(self, knowledge: str) -> bool:
+        """Return True if *knowledge* fits within the configured token budget.
+
+        Always returns True when ``max_knowledge_tokens`` is not set.
+        """
+        if self.max_knowledge_tokens is None:
+            return True
+        return KnowledgeTruncator.fits(
+            knowledge, self.max_knowledge_tokens, self.llm_model
+        )
+
+    def apply_overflow_strategy(self, knowledge: str) -> str:
+        """Apply the non-async overflow strategies (IGNORE / TRUNCATE / RAISE).
+
+        MAP_REDUCE requires an async LLM call — use ``apply_overflow_strategy_async``
+        for that strategy.  Calling this method with MAP_REDUCE raises RuntimeError.
+        """
+        if self.max_knowledge_tokens is None or self.overflow_strategy == OverflowStrategy.IGNORE:
+            return knowledge
+
+        if self.overflow_strategy == OverflowStrategy.RAISE:
+            if not KnowledgeTruncator.fits(
+                    knowledge, self.max_knowledge_tokens, self.llm_model
+            ):
+                raise ValueError(
+                    f"Retrieved knowledge exceeds token budget "
+                    f"({self.max_knowledge_tokens} tokens). "
+                    "Set overflow_strategy=TRUNCATE to truncate automatically, "
+                    "or increase max_knowledge_tokens."
+                )
+            return knowledge
+
+        if self.overflow_strategy == OverflowStrategy.TRUNCATE:
+            result, was_truncated = KnowledgeTruncator.truncate(
+                knowledge, self.max_knowledge_tokens, self.llm_model
+            )
+            if was_truncated:
+                original_tokens = TokenEstimator.count_tokens(knowledge, self.llm_model)
+                logger.warning(
+                    "RAGAgent '%s': retrieved knowledge truncated from ~%d tokens "
+                    "to fit %d-token budget.",
+                    self.name,
+                    original_tokens,
+                    self.max_knowledge_tokens,
+                )
+            return result
+
+        raise RuntimeError(
+            f"overflow_strategy={self.overflow_strategy!r} requires an async call; "
+            "use apply_overflow_strategy_async instead."
+        )
+
+    async def apply_overflow_strategy_async(
+            self, knowledge: str, oxy_request: OxyRequest
+    ) -> str:
+        """Apply the configured overflow strategy, including the async MAP_REDUCE path."""
+        if self.overflow_strategy != OverflowStrategy.MAP_REDUCE:
+            return self.apply_overflow_strategy(knowledge)
+
+        if self.max_knowledge_tokens is None:
+            return knowledge
+
+        return await self._map_reduce_collapse(knowledge, oxy_request)
+
+    # ------------------------------------------------------------------
+    # MAP_REDUCE: recursive collapse
+    # ------------------------------------------------------------------
+
+    async def _collapse_chunk(self, chunk: str, oxy_request: OxyRequest) -> str:
+        """Summarise a single chunk via the LLM."""
+        prompt = self.collapse_prompt.format(text=chunk)
+        temp_memory = Memory()
+        temp_memory.add_message(Message.user_message(prompt))
+        response = await oxy_request.call(
+            callee=self.llm_model,
+            arguments={"messages": temp_memory.to_dict_list()},
+        )
+        if response.state != OxyState.COMPLETED:
+            logger.warning(
+                "RAGAgent '%s': LLM call failed during MAP_REDUCE collapse (state=%s, output=%r); chunk dropped.",
+                self.name,
+                response.state,
+                response.output,
+            )
+            return ""
+        output = response.output
+        return str(output) if output else ""
+
+    async def _map_reduce_collapse(
+            self, knowledge: str, oxy_request: OxyRequest
+    ) -> str:
+        """Recursively collapse *knowledge* until it fits within the token budget.
+
+        Each round: split into chunks, summarise each concurrently, join results.
+        Repeats until the combined text fits or collapse_max_retries is exhausted.
+        Raises ValueError when retries are exhausted.
+        """
+        budget = self.max_knowledge_tokens
+        text = knowledge
+
+        for attempt in range(self.collapse_max_retries):
+            if KnowledgeTruncator.fits(text, budget, self.llm_model):
+                return text
+
+            chunks = KnowledgeTruncator.split_to_chunks(
+                text, budget, self.llm_model
+            )
+            if not chunks:
+                return ""
+
+            logger.info(
+                "RAGAgent '%s': MAP_REDUCE collapse round %d — %d chunks.",
+                self.name,
+                attempt + 1,
+                len(chunks),
+            )
+
+            results: list = await asyncio.gather(
+                # Clone oxy_request per chunk so each call gets its own node ID
+                # without overwriting the parent request's latest_node_ids.
+                *[self._collapse_chunk(c, oxy_request.clone_with()) for c in chunks],
+                return_exceptions=True,
+            )
+            summaries = []
+            for i, r in enumerate(results):
+                if isinstance(r, BaseException):
+                    # Re-raise non-Exception base types (CancelledError, SystemExit, etc.)
+                    if not isinstance(r, Exception):
+                        raise r
+                    logger.warning(
+                        "RAGAgent '%s': _collapse_chunk[%d] raised %s; chunk dropped.",
+                        self.name, i, type(r).__name__,
+                    )
+                elif r:
+                    summaries.append(r)
+
+            text = "\n\n".join(summaries)
+            if not text:
+                logger.warning(
+                    "RAGAgent '%s': all chunk summaries returned empty in round %d.",
+                    self.name,
+                    attempt + 1,
+                )
+                return ""
+            # Check after each round — the last round's result may already fit.
+            if KnowledgeTruncator.fits(text, budget, self.llm_model):
+                return text
+
+        raise ValueError(
+            f"RAGAgent '{self.name}': MAP_REDUCE failed to collapse knowledge "
+            f"into {budget} tokens after {self.collapse_max_retries} rounds."
+        )
+
+    # ------------------------------------------------------------------
+    # Pre-process override
+    # ------------------------------------------------------------------
 
     async def _pre_process(self, oxy_request: OxyRequest) -> OxyRequest:
         """Retrieve relevant context and inject it into the request before execution."""
         oxy_request = await super()._pre_process(oxy_request)
         knowledge = await self.func_retrieve_knowledge(oxy_request)
+        if knowledge is None:
+            knowledge = ""
+        knowledge = await self.apply_overflow_strategy_async(knowledge, oxy_request)
         oxy_request.arguments[self.knowledge_placeholder] = knowledge
         return oxy_request

--- a/oxygent/utils/token_utils.py
+++ b/oxygent/utils/token_utils.py
@@ -246,8 +246,8 @@ class TokenEstimator:
         encoder = cls.get_encoder(model_name)
         if encoder is not None:
             return len(encoder.encode(text))
-        # Fallback: ~4 characters per token
-        return len(text) // 4
+        # Fallback: ~4 characters per token, minimum 1 to avoid zero separator cost
+        return max(1, len(text) // 4)
 
     @classmethod
     def estimate_messages_tokens(
@@ -298,3 +298,144 @@ class TokenEstimator:
                 else EstimationMethod.APPROXIMATE
             ),
         )
+
+
+# ---------------------------------------------------------------------------
+# RAG knowledge context management
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeTruncator:
+    """Truncate and split retrieved knowledge to fit within a token budget.
+
+    Typical flow:
+    1. Call ``fits(text, budget)`` to check whether the knowledge fits as-is.
+    2. If not, call ``truncate(text, budget)`` (simple tail-cut) or
+       ``split_to_chunks(text, budget)`` (chunk list for map-reduce style use).
+    """
+
+    @classmethod
+    def fits(cls, text: str, token_budget: int, model_name: str = "default") -> bool:
+        """Return True if *text* fits within *token_budget* tokens."""
+        return TokenEstimator.count_tokens(text, model_name) <= token_budget
+
+    @classmethod
+    def truncate(
+        cls,
+        text: str,
+        token_budget: int,
+        model_name: str = "default",
+    ) -> tuple[str, bool]:
+        """Truncate *text* to fit within *token_budget* tokens.
+
+        Returns:
+            (truncated_text, was_truncated): The (possibly shortened) text and
+            a flag indicating whether any content was dropped.
+
+        Strategy: binary-search on character index to find the largest prefix
+        that fits, then snap to the nearest paragraph/sentence boundary.
+        Falls back to a hard character cut when no boundary is found.
+        """
+        if not text:
+            return text, False
+
+        if cls.fits(text, token_budget, model_name):
+            return text, False
+
+        # Binary search on character position for the largest fitting prefix.
+        lo, hi = 0, len(text)
+        while lo < hi - 1:
+            mid = (lo + hi) // 2
+            if TokenEstimator.count_tokens(text[:mid], model_name) <= token_budget:
+                lo = mid
+            else:
+                hi = mid
+
+        # Snap to nearest paragraph or sentence boundary to avoid mid-word cuts.
+        candidate = text[:lo]
+        for sep in ("\n\n", "\n", ". ", "。", " "):
+            idx = candidate.rfind(sep)
+            if idx > lo // 2:  # don't snap back more than half the content
+                candidate = candidate[: idx + len(sep)].rstrip()
+                break
+
+        truncated = candidate or text[:lo]
+        return truncated, True
+
+    @classmethod
+    def split_to_chunks(
+        cls,
+        text: str,
+        chunk_token_size: int,
+        model_name: str = "default",
+        separator: str = "\n\n",
+    ) -> list[str]:
+        """Split *text* into a list of chunks each fitting within *chunk_token_size*.
+
+        Splits on *separator* first; if a single paragraph exceeds the budget
+        it is further split on whitespace, then hard-cut as a last resort.
+
+        Returns:
+            List of non-empty string chunks.
+        """
+        if not text:
+            return []
+
+        if chunk_token_size <= 0:
+            raise ValueError(f"chunk_token_size must be > 0, got {chunk_token_size}")
+
+        if not separator:
+            raise ValueError("separator must be a non-empty string")
+
+        paragraphs = text.split(separator)
+        chunks: list[str] = []
+        current_parts: list[str] = []
+        current_tokens = 0
+        sep_tokens = TokenEstimator.count_tokens(separator, model_name)
+
+        for para in paragraphs:
+            if not para.strip():
+                continue
+
+            para_tokens = TokenEstimator.count_tokens(para, model_name)
+
+            if para_tokens > chunk_token_size:
+                # Para itself is oversized — flush current buffer first
+                if current_parts:
+                    chunks.append(separator.join(current_parts))
+                    current_parts, current_tokens = [], 0
+                # Hard-cut the oversized para into token-sized pieces
+                chunks.extend(
+                    cls._hard_cut(para, chunk_token_size, model_name)
+                )
+                continue
+
+            # Account for the separator that join() will insert between parts.
+            join_cost = sep_tokens if current_parts else 0
+            if current_tokens + join_cost + para_tokens > chunk_token_size and current_parts:
+                chunks.append(separator.join(current_parts))
+                current_parts, current_tokens = [], 0
+
+            current_parts.append(para)
+            current_tokens += (sep_tokens if len(current_parts) > 1 else 0) + para_tokens
+
+        if current_parts:
+            chunks.append(separator.join(current_parts))
+
+        return chunks
+
+    @classmethod
+    def _hard_cut(
+        cls, text: str, token_budget: int, model_name: str
+    ) -> list[str]:
+        """Cut *text* into pieces of at most *token_budget* tokens each."""
+        pieces: list[str] = []
+        remaining = text
+        while remaining:
+            piece, _ = cls.truncate(remaining, token_budget, model_name)
+            if not piece:
+                # Safety: avoid infinite loop if truncate returns empty
+                piece = remaining[: max(1, len(remaining) // 2)]
+            pieces.append(piece)
+            remaining = remaining[len(piece):]
+        return pieces

--- a/tests/unittest/test_knowledge_truncator.py
+++ b/tests/unittest/test_knowledge_truncator.py
@@ -1,0 +1,140 @@
+"""Unit tests for KnowledgeTruncator (token_utils)."""
+
+import pytest
+
+from oxygent.utils.token_utils import KnowledgeTruncator, TokenEstimator
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def approx_tokens(text: str) -> int:
+    return TokenEstimator.count_tokens(text, "default")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def patched_config(monkeypatch):
+    monkeypatch.setattr(
+        "oxygent.oxy.agents.local_agent.Config.get_agent_llm_model",
+        lambda: "mock_llm",
+    )
+    monkeypatch.setattr(
+        "oxygent.oxy.agents.local_agent.Config.get_agent_prompt",
+        lambda: "",
+    )
+    monkeypatch.setattr(
+        "oxygent.oxy.agents.local_agent.Config.get_vearch_config",
+        lambda: {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# KnowledgeTruncator.fits
+# ---------------------------------------------------------------------------
+
+class TestFits:
+    def test_empty_text_always_fits(self):
+        assert KnowledgeTruncator.fits("", 10) is True
+
+    def test_short_text_fits(self):
+        assert KnowledgeTruncator.fits("hello", 100) is True
+
+    def test_text_exactly_at_budget(self):
+        text = "a" * 4  # ~1 token with char-based estimator
+        assert KnowledgeTruncator.fits(text, 1) is True
+
+    def test_text_over_budget(self):
+        text = "word " * 100  # ~100 tokens
+        assert KnowledgeTruncator.fits(text, 10) is False
+
+
+# ---------------------------------------------------------------------------
+# KnowledgeTruncator.truncate
+# ---------------------------------------------------------------------------
+
+class TestTruncate:
+    def test_no_truncation_when_fits(self):
+        text = "short text"
+        result, truncated = KnowledgeTruncator.truncate(text, 1000)
+        assert result == text
+        assert truncated is False
+
+    def test_truncation_when_over_budget(self):
+        text = "word " * 200
+        result, truncated = KnowledgeTruncator.truncate(text, 50)
+        assert truncated is True
+        assert approx_tokens(result) <= 50
+
+    def test_truncated_result_is_non_empty(self):
+        text = "word " * 500
+        result, _ = KnowledgeTruncator.truncate(text, 20)
+        assert len(result) > 0
+
+    def test_empty_text_unchanged(self):
+        result, truncated = KnowledgeTruncator.truncate("", 100)
+        assert result == ""
+        assert truncated is False
+
+    def test_snaps_to_paragraph_boundary(self):
+        para1 = "First paragraph. " * 20
+        para2 = "Second paragraph. " * 20
+        text = para1 + "\n\n" + para2
+        result, truncated = KnowledgeTruncator.truncate(text, 60)
+        assert truncated is True
+        assert result.strip() != ""
+
+    def test_result_fits_budget_strictly(self):
+        text = "token " * 300
+        result, _ = KnowledgeTruncator.truncate(text, 80)
+        assert approx_tokens(result) <= 80
+
+
+# ---------------------------------------------------------------------------
+# KnowledgeTruncator.split_to_chunks
+# ---------------------------------------------------------------------------
+
+class TestSplitToChunks:
+    def test_empty_text_returns_empty_list(self):
+        assert KnowledgeTruncator.split_to_chunks("", 100) == []
+
+    def test_short_text_is_single_chunk(self):
+        text = "hello world"
+        chunks = KnowledgeTruncator.split_to_chunks(text, 100)
+        assert len(chunks) == 1
+        assert chunks[0] == text
+
+    def test_multiple_chunks_each_within_budget(self):
+        text = "\n\n".join(["paragraph " * 20] * 10)
+        chunks = KnowledgeTruncator.split_to_chunks(text, 40)
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert approx_tokens(chunk) <= 40
+
+    def test_chunks_preserve_all_content(self):
+        words = ["alpha", "beta", "gamma", "delta", "epsilon"]
+        text = "\n\n".join(words)
+        chunks = KnowledgeTruncator.split_to_chunks(text, 5)
+        joined = " ".join(chunks)
+        for w in words:
+            assert w in joined
+
+    def test_invalid_chunk_size_raises(self):
+        with pytest.raises(ValueError):
+            KnowledgeTruncator.split_to_chunks("text", 0)
+
+    def test_oversized_single_paragraph_is_hard_cut(self):
+        text = "x " * 400
+        chunks = KnowledgeTruncator.split_to_chunks(text, 50)
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert approx_tokens(chunk) <= 50
+
+    def test_whitespace_only_paragraphs_skipped(self):
+        text = "para one\n\n   \n\npara two"
+        chunks = KnowledgeTruncator.split_to_chunks(text, 100)
+        assert all(c.strip() for c in chunks)

--- a/tests/unittest/test_rag_agent.py
+++ b/tests/unittest/test_rag_agent.py
@@ -1,16 +1,26 @@
-"""Unit tests for oxygent.oxy.agents.rag_agent (RAGAgent)."""
+"""Unit tests for RAGAgent — overflow strategies and MAP_REDUCE collapse."""
 
+import asyncio
+import pytest
 from unittest.mock import AsyncMock
 
-import pytest
-
-from oxygent.oxy.agents.rag_agent import RAGAgent
+from oxygent.oxy.agents.rag_agent import OverflowStrategy, RAGAgent
 from oxygent.schemas import OxyRequest
+from oxygent.utils.token_utils import TokenEstimator
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Dummy MAS
-# ──────────────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def approx_tokens(text: str) -> int:
+    return TokenEstimator.count_tokens(text, "default")
+
+
+# ---------------------------------------------------------------------------
+# DummyMAS
+# ---------------------------------------------------------------------------
+
 class DummyMAS:
     def __init__(self):
         self.oxy_name_to_oxy = {}
@@ -29,10 +39,11 @@ class DummyMAS:
         return False
 
 
-# ──────────────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
 # Fixtures
-# ──────────────────────────────────────────────────────────────────────────────
-@pytest.fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
 def patched_config(monkeypatch):
     monkeypatch.setattr(
         "oxygent.oxy.agents.local_agent.Config.get_agent_llm_model",
@@ -51,73 +62,413 @@ def patched_config(monkeypatch):
     )
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Tests
-# ──────────────────────────────────────────────────────────────────────────────
-def test_default_prompt_injected(patched_config):
-    """Without explicit prompt, default RAG prompt is set."""
-
-    async def dummy_retrieve(req):
-        return "context"
-
-    agent = RAGAgent(
-        name="rag",
-        func_retrieve_knowledge=dummy_retrieve,
-    )
-    assert "${knowledge}" in agent.prompt
-
-
-def test_custom_prompt_preserved(patched_config):
-    """Explicit prompt is not overwritten."""
-
-    async def dummy_retrieve(req):
-        return "context"
-
-    agent = RAGAgent(
-        name="rag",
-        prompt="Custom prompt ${info}",
-        func_retrieve_knowledge=dummy_retrieve,
-    )
-    assert agent.prompt == "Custom prompt ${info}"
-
-
-def test_custom_placeholder(patched_config):
-    """Custom knowledge_placeholder is used in default prompt."""
-
-    async def dummy_retrieve(req):
-        return "context"
-
-    agent = RAGAgent(
-        name="rag",
-        knowledge_placeholder="context",
-        func_retrieve_knowledge=dummy_retrieve,
-    )
-    assert "${context}" in agent.prompt
-
-
-@pytest.mark.asyncio
-async def test_pre_process_injects_knowledge(patched_config):
-    """_pre_process calls retrieve function and injects knowledge."""
-
-    async def mock_retrieve(req):
-        return "retrieved knowledge"
-
-    agent = RAGAgent(
-        name="rag",
-        func_retrieve_knowledge=mock_retrieve,
-    )
-    mas = DummyMAS()
-    agent.set_mas(mas)
-
+def make_request(mas):
     req = OxyRequest(
         arguments={"query": "hello"},
         caller="user",
         caller_category="user",
     )
     req.mas = mas
+    return req
 
-    # monkeypatch the parent's _pre_process to just return the request
-    original_pre_process = agent._pre_process
 
-    result = await agent._pre_process(req)
-    assert result.arguments["knowledge"] == "retrieved knowledge"
+# ---------------------------------------------------------------------------
+# Construction & prompt injection
+# ---------------------------------------------------------------------------
+
+def test_default_prompt_injected():
+    agent = RAGAgent(name="rag", func_retrieve_knowledge=AsyncMock())
+    assert "${knowledge}" in agent.prompt
+
+
+def test_custom_prompt_preserved():
+    agent = RAGAgent(
+        name="rag",
+        prompt="Custom prompt ${info}",
+        func_retrieve_knowledge=AsyncMock(),
+    )
+    assert agent.prompt == "Custom prompt ${info}"
+
+
+def test_custom_placeholder_in_prompt():
+    agent = RAGAgent(
+        name="rag",
+        knowledge_placeholder="context",
+        func_retrieve_knowledge=AsyncMock(),
+    )
+    assert "${context}" in agent.prompt
+
+
+def test_empty_knowledge_placeholder_raises():
+    with pytest.raises(Exception):
+        RAGAgent(name="r", func_retrieve_knowledge=AsyncMock(), knowledge_placeholder="")
+
+
+# ---------------------------------------------------------------------------
+# collapse_prompt validation
+# ---------------------------------------------------------------------------
+
+def test_default_collapse_prompt_valid():
+    agent = RAGAgent(name="r", func_retrieve_knowledge=AsyncMock())
+    assert "{text}" in agent.collapse_prompt
+
+
+def test_valid_custom_collapse_prompt():
+    agent = RAGAgent(
+        name="r",
+        func_retrieve_knowledge=AsyncMock(),
+        collapse_prompt="Please summarize: {text}",
+    )
+    assert agent.collapse_prompt == "Please summarize: {text}"
+
+
+def test_collapse_prompt_missing_text_raises():
+    with pytest.raises(Exception, match="\\{text\\}"):
+        RAGAgent(
+            name="r",
+            func_retrieve_knowledge=AsyncMock(),
+            collapse_prompt="Summarize the above.",
+        )
+
+
+def test_collapse_prompt_extra_placeholder_raises():
+    with pytest.raises(Exception):
+        RAGAgent(
+            name="r",
+            func_retrieve_knowledge=AsyncMock(),
+            collapse_prompt="Summarize {text} for {audience}.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# knowledge_fits
+# ---------------------------------------------------------------------------
+
+def test_knowledge_fits_no_budget():
+    agent = RAGAgent(name="r", func_retrieve_knowledge=AsyncMock())
+    assert agent.knowledge_fits("any text" * 1000) is True
+
+
+def test_knowledge_fits_within_budget():
+    agent = RAGAgent(name="r", func_retrieve_knowledge=AsyncMock(), max_knowledge_tokens=500)
+    assert agent.knowledge_fits("hello") is True
+
+
+def test_knowledge_fits_exceeds_budget():
+    agent = RAGAgent(name="r", func_retrieve_knowledge=AsyncMock(), max_knowledge_tokens=10)
+    assert agent.knowledge_fits("word " * 100) is False
+
+
+# ---------------------------------------------------------------------------
+# apply_overflow_strategy — sync strategies
+# ---------------------------------------------------------------------------
+
+class TestOverflowStrategy:
+    def _agent(self, strategy, budget=50):
+        return RAGAgent(
+            name="r",
+            func_retrieve_knowledge=AsyncMock(),
+            max_knowledge_tokens=budget,
+            overflow_strategy=strategy,
+        )
+
+    def test_ignore_returns_full_text(self):
+        agent = self._agent(OverflowStrategy.IGNORE)
+        long_text = "word " * 200
+        assert agent.apply_overflow_strategy(long_text) == long_text
+
+    def test_raise_on_overflow(self):
+        agent = self._agent(OverflowStrategy.RAISE, budget=5)
+        with pytest.raises(ValueError, match="token budget"):
+            agent.apply_overflow_strategy("word " * 100)
+
+    def test_raise_no_error_when_fits(self):
+        agent = self._agent(OverflowStrategy.RAISE, budget=1000)
+        assert agent.apply_overflow_strategy("short text") == "short text"
+
+    def test_truncate_shortens_text(self):
+        agent = self._agent(OverflowStrategy.TRUNCATE, budget=20)
+        result = agent.apply_overflow_strategy("token " * 200)
+        assert approx_tokens(result) <= 20
+
+    def test_truncate_leaves_short_text_unchanged(self):
+        agent = self._agent(OverflowStrategy.TRUNCATE, budget=1000)
+        assert agent.apply_overflow_strategy("short text") == "short text"
+
+    def test_no_budget_returns_unchanged(self):
+        agent = RAGAgent(name="r", func_retrieve_knowledge=AsyncMock())
+        text = "word " * 500
+        assert agent.apply_overflow_strategy(text) == text
+
+    def test_map_reduce_on_sync_method_raises_runtime_error(self):
+        """apply_overflow_strategy (sync) raises RuntimeError for MAP_REDUCE."""
+        agent = RAGAgent(
+            name="r",
+            func_retrieve_knowledge=AsyncMock(),
+            max_knowledge_tokens=10,
+            overflow_strategy=OverflowStrategy.MAP_REDUCE,
+        )
+        with pytest.raises(RuntimeError, match="async"):
+            agent.apply_overflow_strategy("word " * 100)
+
+
+# ---------------------------------------------------------------------------
+# _pre_process integration
+# ---------------------------------------------------------------------------
+
+class TestPreProcess:
+    def _make_agent(self, retrieve_fn, budget=None, strategy=OverflowStrategy.TRUNCATE):
+        agent = RAGAgent(
+            name="rag",
+            func_retrieve_knowledge=retrieve_fn,
+            max_knowledge_tokens=budget,
+            overflow_strategy=strategy,
+        )
+        mas = DummyMAS()
+        agent.set_mas(mas)
+        return agent
+
+    @pytest.mark.asyncio
+    async def test_knowledge_injected(self):
+        async def retrieve(req):
+            return "some knowledge"
+
+        agent = self._make_agent(retrieve)
+        req = make_request(agent.mas)
+        result = await agent._pre_process(req)
+        assert result.arguments["knowledge"] == "some knowledge"
+
+    @pytest.mark.asyncio
+    async def test_none_retrieval_becomes_empty_string(self):
+        async def retrieve(req):
+            return None
+
+        agent = self._make_agent(retrieve)
+        req = make_request(agent.mas)
+        result = await agent._pre_process(req)
+        assert result.arguments["knowledge"] == ""
+
+    @pytest.mark.asyncio
+    async def test_truncate_applied(self):
+        async def retrieve(req):
+            return "word " * 200
+
+        agent = self._make_agent(retrieve, budget=30, strategy=OverflowStrategy.TRUNCATE)
+        req = make_request(agent.mas)
+        result = await agent._pre_process(req)
+        assert approx_tokens(result.arguments["knowledge"]) <= 30
+
+    @pytest.mark.asyncio
+    async def test_raise_propagates(self):
+        async def retrieve(req):
+            return "word " * 200
+
+        agent = self._make_agent(retrieve, budget=10, strategy=OverflowStrategy.RAISE)
+        req = make_request(agent.mas)
+        with pytest.raises(ValueError, match="token budget"):
+            await agent._pre_process(req)
+
+    @pytest.mark.asyncio
+    async def test_ignore_passes_full_text(self):
+        long_text = "word " * 300
+
+        async def retrieve(req):
+            return long_text
+
+        agent = self._make_agent(retrieve, budget=10, strategy=OverflowStrategy.IGNORE)
+        req = make_request(agent.mas)
+        result = await agent._pre_process(req)
+        assert result.arguments["knowledge"] == long_text
+
+    @pytest.mark.asyncio
+    async def test_custom_placeholder(self):
+        async def retrieve(req):
+            return "ctx"
+
+        agent = RAGAgent(
+            name="rag",
+            func_retrieve_knowledge=retrieve,
+            knowledge_placeholder="ctx_data",
+        )
+        mas = DummyMAS()
+        agent.set_mas(mas)
+        result = await agent._pre_process(make_request(mas))
+        assert result.arguments["ctx_data"] == "ctx"
+
+
+# ---------------------------------------------------------------------------
+# MAP_REDUCE collapse
+# ---------------------------------------------------------------------------
+
+class TestMapReduceCollapse:
+    def _make_agent(self, budget, collapse_fn=None, max_retries=3):
+        agent = RAGAgent(
+            name="mr",
+            func_retrieve_knowledge=AsyncMock(return_value=""),
+            max_knowledge_tokens=budget,
+            overflow_strategy=OverflowStrategy.MAP_REDUCE,
+            collapse_max_retries=max_retries,
+        )
+        mas = DummyMAS()
+        agent.set_mas(mas)
+        if collapse_fn:
+            agent._collapse_chunk = collapse_fn
+        return agent
+
+    @pytest.mark.asyncio
+    async def test_already_fits_no_llm_call(self):
+        called = []
+
+        async def never_called(chunk, req):
+            called.append(chunk)
+            return "summary"
+
+        agent = self._make_agent(budget=1000, collapse_fn=never_called)
+        req = make_request(agent.mas)
+        result = await agent._map_reduce_collapse("short knowledge", req)
+        assert result == "short knowledge"
+        assert called == []
+
+    @pytest.mark.asyncio
+    async def test_single_round_converges(self):
+        summaries = []
+
+        async def summarise(chunk, req):
+            s = f"S{len(summaries)}"
+            summaries.append(s)
+            return s
+
+        agent = self._make_agent(budget=100, collapse_fn=summarise)
+        req = make_request(agent.mas)
+        result = await agent._map_reduce_collapse("word " * 500, req)
+        assert approx_tokens(result) <= 100
+        assert len(summaries) >= 1
+
+    @pytest.mark.asyncio
+    async def test_multi_round_converges(self):
+        round_counts = [0]
+
+        async def verbose_summary(chunk, req):
+            round_counts[0] += 1
+            if round_counts[0] <= 3:
+                return "word " * 20
+            return "tiny"
+
+        agent = self._make_agent(budget=10, collapse_fn=verbose_summary, max_retries=5)
+        req = make_request(agent.mas)
+        result = await agent._map_reduce_collapse("word " * 300, req)
+        assert approx_tokens(result) <= 10
+        assert round_counts[0] > 1
+
+    @pytest.mark.asyncio
+    async def test_max_retries_1_converges_without_raise(self):
+        """Single retry: summary fits → return, do not raise ValueError."""
+
+        async def small_summary(chunk, req):
+            return "ok"
+
+        agent = self._make_agent(budget=100, collapse_fn=small_summary, max_retries=1)
+        req = make_request(agent.mas)
+        result = await agent._map_reduce_collapse("word " * 300, req)
+        assert approx_tokens(result) <= 100
+
+    @pytest.mark.asyncio
+    async def test_exhausted_retries_raises(self):
+        async def always_large(chunk, req):
+            return "word " * 100
+
+        agent = self._make_agent(budget=5, collapse_fn=always_large, max_retries=2)
+        req = make_request(agent.mas)
+        with pytest.raises(ValueError, match="MAP_REDUCE failed"):
+            await agent._map_reduce_collapse("word " * 200, req)
+
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty(self):
+        agent = self._make_agent(budget=50)
+        req = make_request(agent.mas)
+        assert await agent._map_reduce_collapse("", req) == ""
+
+    @pytest.mark.asyncio
+    async def test_all_empty_summaries_returns_empty(self):
+        async def empty_summarise(chunk, req):
+            return ""
+
+        agent = self._make_agent(budget=10, collapse_fn=empty_summarise, max_retries=3)
+        req = make_request(agent.mas)
+        result = await agent._map_reduce_collapse("word " * 100, req)
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_failed_chunk_dropped(self):
+        call_count = [0]
+
+        async def fake_collapse(chunk, req):
+            call_count[0] += 1
+            return "" if call_count[0] == 1 else "summary"
+
+        agent = self._make_agent(budget=100, collapse_fn=fake_collapse, max_retries=3)
+        req = make_request(agent.mas)
+        text = "\n\n".join(["word " * 50] * 2)
+        result = await agent._map_reduce_collapse(text, req)
+        assert "summary" in result
+        assert call_count[0] == 2
+
+    @pytest.mark.asyncio
+    async def test_chunks_summarized_concurrently(self):
+        start_times = []
+        end_times = []
+
+        async def slow_summarise(chunk, req):
+            start_times.append(asyncio.get_event_loop().time())
+            await asyncio.sleep(0.05)
+            end_times.append(asyncio.get_event_loop().time())
+            return "s"
+
+        agent = self._make_agent(budget=100, collapse_fn=slow_summarise)
+        req = make_request(agent.mas)
+        text = "\n\n".join(["word " * 50] * 3)
+        await agent._map_reduce_collapse(text, req)
+        assert len(start_times) >= 2
+        assert max(start_times) < min(end_times)
+
+    @pytest.mark.asyncio
+    async def test_map_reduce_no_budget_passthrough(self):
+        """MAP_REDUCE + no budget → knowledge passed unchanged."""
+
+        async def retrieve(req):
+            return "word " * 50
+
+        agent = RAGAgent(
+            name="mr",
+            func_retrieve_knowledge=retrieve,
+            overflow_strategy=OverflowStrategy.MAP_REDUCE,
+        )
+        mas = DummyMAS()
+        agent.set_mas(mas)
+        result = await agent._pre_process(make_request(mas))
+        assert result.arguments["knowledge"] == "word " * 50
+
+    @pytest.mark.asyncio
+    async def test_pre_process_uses_map_reduce(self):
+        collapse_calls = []
+
+        async def summarise(chunk, req):
+            collapse_calls.append(chunk)
+            return "ok"
+
+        async def retrieve(req):
+            return "word " * 200
+
+        agent = RAGAgent(
+            name="mr",
+            func_retrieve_knowledge=retrieve,
+            max_knowledge_tokens=10,
+            overflow_strategy=OverflowStrategy.MAP_REDUCE,
+            collapse_max_retries=3,
+        )
+        mas = DummyMAS()
+        agent.set_mas(mas)
+        agent._collapse_chunk = summarise
+        result = await agent._pre_process(make_request(mas))
+        assert approx_tokens(result.arguments["knowledge"]) <= 10
+        assert len(collapse_calls) >= 1


### PR DESCRIPTION
---
Summary

为 RAGAgent 新增上下文超限保护能力，支持三种溢出处理策略（TRUNCATE/RAISE/MAP_REDUCE），并引入 KnowledgeTruncator 工具类用于 token 检测、截断和分块。同时修复了 LocalAgent.__deepcopy__ 在子类有 exclude=True 必填字段时重建失败的问题。

Related Issue(s)

N/A

Changes

- [x] Feature: RAG 召回内容超限检测与处理

- 在 RAGAgent 新增 max_knowledge_tokens 和 overflow_strategy 字段，支持以下四种策略：
  - IGNORE（默认）：原有行为，透传给 LLM
  - TRUNCATE：截取最大合适前缀并告警
  - RAISE：超限时直接抛出 ValueError
  - MAP_REDUCE：将内容分块，逐块调 LLM 摘要，递归折叠直到符合预算
- [x] Feature: KnowledgeTruncator 工具类

- 新增 oxygent/utils/token_utils.py 中的 KnowledgeTruncator，提供：
  - fits(text, budget)：token 数检测
  - truncate(text, budget)：二分查找截断 + 段落边界对齐
  - split_to_chunks(text, chunk_size)：按段落分块，超大段自动硬切
- [x] Fix: LocalAgent.deepcopy 重建子类时丢失 exclude=True 字段

- 原先 model_dump() 会跳过 exclude=True 字段（如 func_retrieve_knowledge），导致 team_size > 1 时 deepcopy 抛 ValidationError 或缺失 _semaphore。现在统一通过 type(self).model_fields 补回被排除字段，并改用 self.__class__(**fields) 走完整 __init__ 流程。
- [x] Tests: 单测补充

  - test_knowledge_truncator.py：覆盖 KnowledgeTruncator 的 fits/truncate/split 逻辑
  - test_rag_agent.py：覆盖四种策略的同步/异步路径、MAP_REDUCE 多轮折叠、并发执行、边界情况（空输入、retry 耗尽、chunk 失败等），共 52 个用例

Screenshots (if UI changes)

N/A

Checklist

- [x] been self-reviewed.
  - [x] Code is formatted
  - [x] Tests added/updated
  - [x] All CI checks passed
  - [ ] Documentation updated
- [ ] added documentation for new or modified features or behaviors.
- [x] added new features, such as new agents, new flows, etc.
- [ ] added or updated version, license, or notice information.
- [x] added or updated demo, integration tests, unit tests, or others.
- [ ] added or updated ui, or had changes in frontend.