### PR TITLE
feat: add alias display for Agent nodes in web UI (#135)

### DIFF
--- a/oxygent/mas.py
+++ b/oxygent/mas.py
@@ -767,6 +767,7 @@ class MAS(BaseModel):
                 agent_organization.append(
                     {
                         "name": agent_name,
+                        "alias": agent.alias or agent_name,
                         "type": agent.category,
                     }
                 )

--- a/oxygent/oxy/base_oxy.py
+++ b/oxygent/oxy/base_oxy.py
@@ -87,6 +87,10 @@ class Oxy(BaseModel, ABC):
     """
 
     name: str = Field(..., description="Identifier for the agent.")
+    alias: Optional[str] = Field(
+        None,
+        description="Human-friendly display name shown in the web UI; falls back to name.",
+    )
     desc: str = Field("", description="Description of the agent's functionality.")
     category: str = Field("tool", description="Category classification")
     class_name: Optional[str] = Field(None, description="Class name")

--- a/oxygent/web/index.html
+++ b/oxygent/web/index.html
@@ -1121,8 +1121,8 @@
                     : `<img src='${typeMap[data.type]}' />`
                 }
                         </span>
-                        <span class='item-template-text'>
-                            ${data.name}
+                        <span class='item-template-text' title='${data.name}'>
+                            ${data.alias || data.name}
                         </span>
                         ${data?.children?.length
                     ? '<div class="expandIcon">-</div>'


### PR DESCRIPTION
## Summary

Closes #135

The MAS visualization currently displays each node's `name` (e.g. `master_agent`,
`file_agent`), which is a code-level identifier and not very user-friendly,
especially for non-English business users.

This PR introduces an optional `alias` field — a **display-only** human-friendly
name rendered in the web UI organization tree, while `name` remains the sole
functional identifier throughout the system.

## Usage

```python
oxy.ReActAgent(
    name="calc_agent",      # functional identifier (unchanged)
    alias="计算专家",        # display name shown in the web UI
    ...
)


```
<h2 style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-size: 1.07143em; font-weight: 500; line-height: 1.33333; color: rgb(110, 108, 104); font-family: &quot;Anthropic Sans&quot;, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(253, 253, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h2><div class="overflow-x-auto" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); overflow-x: auto; color: rgb(10, 10, 10); font-family: &quot;Anthropic Sans&quot;, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(253, 253, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
File | Change
-- | --
oxygent/oxy/base_oxy.py | Add optional alias field on the Oxy base class, inherited by all agents/tools/LLMs
oxygent/mas.py | Include alias in the organization tree nodes (init_agent_organization), falling back to name when unset
oxygent/web/index.html | Org-tree template renders alias \|\| name; the real name is kept as a hover tooltip for debugging

</div><p style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); color: rgb(10, 10, 10); font-family: &quot;Anthropic Sans&quot;, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(253, 253, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">7 insertions, 2 deletions — no new dependencies.</p><h2 style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-size: 1.07143em; font-weight: 500; line-height: 1.33333; color: rgb(110, 108, 104); font-family: &quot;Anthropic Sans&quot;, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(253, 253, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Design notes</h2><p style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); color: rgb(10, 10, 10); font-family: &quot;Anthropic Sans&quot;, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(253, 253, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code node="[object Object]" data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-family: &quot;Anthropic Mono&quot;, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(10, 10, 10, 0.04); color: rgb(10, 10, 10); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">alias</code><span> </span>is deliberately<span> </span><strong style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-weight: 500;">presentation-layer only</strong>. The following keep using<br style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);"><code node="[object Object]" data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-family: &quot;Anthropic Mono&quot;, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(10, 10, 10, 0.04); color: rgb(10, 10, 10); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">name</code>, so behavior is fully backward compatible:</p><ul style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px 0px 0px 20px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); list-style: outside; gap: 6px; flex-direction: column; display: flex; color: rgb(10, 10, 10); font-family: &quot;Anthropic Sans&quot;, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(253, 253, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);">LLM-facing tool descriptions and tool-call routing (<code node="[object Object]" data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-family: &quot;Anthropic Mono&quot;, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(10, 10, 10, 0.04); color: rgb(10, 10, 10); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">oxy_request.call</code>)</li><li style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);">Permission lists (<code node="[object Object]" data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-family: &quot;Anthropic Mono&quot;, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(10, 10, 10, 0.04); color: rgb(10, 10, 10); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">sub_agents</code><span> </span>/<span> </span><code node="[object Object]" data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-family: &quot;Anthropic Mono&quot;, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(10, 10, 10, 0.04); color: rgb(10, 10, 10); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">permitted_tool_name_list</code>)</li><li style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);">ES trace records (<code node="[object Object]" data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-family: &quot;Anthropic Mono&quot;, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(10, 10, 10, 0.04); color: rgb(10, 10, 10); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">caller</code><span> </span>/<span> </span><code node="[object Object]" data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-family: &quot;Anthropic Mono&quot;, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(10, 10, 10, 0.04); color: rgb(10, 10, 10); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">callee</code>) and session names</li><li style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);">The chat "@agent" mention list (functional: clicking invokes by name)</li></ul><p style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); color: rgb(10, 10, 10); font-family: &quot;Anthropic Sans&quot;, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(253, 253, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Nodes without an alias fall back to<span> </span><code node="[object Object]" data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-family: &quot;Anthropic Mono&quot;, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(10, 10, 10, 0.04); color: rgb(10, 10, 10); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">name</code>, so existing projects render<br style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);">exactly as before.</p><h2 style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-size: 1.07143em; font-weight: 500; line-height: 1.33333; color: rgb(110, 108, 104); font-family: &quot;Anthropic Sans&quot;, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(253, 253, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Testing</h2><ul style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px 0px 0px 20px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); list-style: outside; gap: 6px; flex-direction: column; display: flex; color: rgb(10, 10, 10); font-family: &quot;Anthropic Sans&quot;, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(253, 253, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);">Verified<span> </span><code node="[object Object]" data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-family: &quot;Anthropic Mono&quot;, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(10, 10, 10, 0.04); color: rgb(10, 10, 10); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">/get_organization</code><span> </span>returns<span> </span><code node="[object Object]" data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-family: &quot;Anthropic Mono&quot;, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(10, 10, 10, 0.04); color: rgb(10, 10, 10); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">alias</code><span> </span>for configured nodes and<br style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);">falls back to<span> </span><code node="[object Object]" data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-family: &quot;Anthropic Mono&quot;, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(10, 10, 10, 0.04); color: rgb(10, 10, 10); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">name</code><span> </span>for others.</li><li style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);">Smoke-tested end-to-end with a 3-agent / 4-tool MAS: org tree shows<br style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);">aliases (see screenshot), hover shows the real name, and a multi-step<br style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);">query (<code node="[object Object]" data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-family: &quot;Anthropic Mono&quot;, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(10, 10, 10, 0.04); color: rgb(10, 10, 10); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">master → text_agent</code>,<span> </span><code node="[object Object]" data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-family: &quot;Anthropic Mono&quot;, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(10, 10, 10, 0.04); color: rgb(10, 10, 10); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">master → calc_agent</code>) completes correctly —<br style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);">call chains and traces are unaffected.</li></ul><h2 style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-size: 1.07143em; font-weight: 500; line-height: 1.33333; color: rgb(110, 108, 104); font-family: &quot;Anthropic Sans&quot;, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(253, 253, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Possible follow-ups (out of scope)</h2><ul style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px 0px 0px 20px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); list-style: outside; gap: 6px; flex-direction: column; display: flex; color: rgb(10, 10, 10); font-family: &quot;Anthropic Sans&quot;, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(253, 253, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);">Show<span> </span><code node="[object Object]" data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0); font-family: &quot;Anthropic Mono&quot;, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(10, 10, 10, 0.04); color: rgb(10, 10, 10); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">alias (name)</code><span> </span>in the node inspector / playground panels (debug views,<br style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);">arguably better with real names — open to discussion)</li><li style="box-sizing: border-box; border: 0px solid color(srgb 0.0431373 0.0431373 0.0431373 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(37, 107, 193); scrollbar-width: thin; scrollbar-color: rgba(31, 31, 30, 0.35) rgba(0, 0, 0, 0);">Alias mapping for MCP-discovered tools (names come from the MCP server)</li></ul>